### PR TITLE
Specify a default sunlight settings for new maps.

### DIFF
--- a/data/default_map_settings.cfg
+++ b/data/default_map_settings.cfg
@@ -14,6 +14,9 @@ exec "data/default_map_models.cfg"
 
 if (strcmp $skybox "") [
     skybox "skyboxes/remus/sky01"
+    sunlightyaw 53
+    sunlightpitch 41
+    sunlight 0xFFEFDF
 ]
 
 materialreset
@@ -43,9 +46,9 @@ texture 0 "textures/default.png" // default geometry texture
 
 texture 0 "aard/aardograss_1.jpg"
 autograss "<agrad:0,0.2>textures/grass_aard.png"
-texture 0 "ik2k/ik_floor_brick128a.jpg" 
-texture 0 "ik2k/ik_floor_wood128b.jpg"  
-texture 0 "ik2k/ik_ground_cobbles128.jpg" 
+texture 0 "ik2k/ik_floor_brick128a.jpg"
+texture 0 "ik2k/ik_floor_wood128b.jpg"
+texture 0 "ik2k/ik_ground_cobbles128.jpg"
 texture 0 "ik2k/ik_brick_3216d.jpg"
 texture 0 "ik2k/ik_brick_6464c.jpg"
 
@@ -59,7 +62,7 @@ exec "packages/jf1/package.cfg"
 
 // misc textures (mine/schwenz/some tech1soc)
 
-texture 0 "aard/aardfdry256_1.jpg"   
+texture 0 "aard/aardfdry256_1.jpg"
 texture 0 "tech1soc/spring3.jpg"
 texture 0 "tech1soc/sqrlig02wb.jpg"
 texture 0 "tech1soc/sqrlig03bc.jpg"


### PR DESCRIPTION
Specify a default sunlight setting for new maps so that they're illuminated when created.
The values were chosen to match skyboxes/remus/sky01, which is the default skybox.

Sorry about the whitespace changes.
