### PR TITLE
Add some .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# ignore compiled objects
+*.[oa]
+*.gch
+
+# ignore backups and other misc files
+*.orig
+*.rej
+*.bak
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@
 *.rej
 *.bak
 *~
+
+# binaries
+/src/tess_client
+/src/tess_server
+/bin_unix/native_*
+

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *~
 
 # binaries
+*.exe
 /src/tess_client
 /src/tess_server
 /bin_unix/native_*

--- a/src/enet/.gitignore
+++ b/src/enet/.gitignore
@@ -1,0 +1,11 @@
+# enet stuff
+*.lo
+*.la
+*.pc
+*.status
+*.log
+libtool
+Makefile
+autom4te.cache/
+.deps/
+.libs/


### PR DESCRIPTION
The two files contain patterns for common backup/temporary files, builds/binaries, and compiled objects.
The one in /src/enet has patterns specifically to match against various files enet generates during build.
